### PR TITLE
CleverTap iOS Kit - updated

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "clevertap/clevertap-ios-sdk" ~> 3.8
+github "clevertap/clevertap-ios-sdk" ~> 3.9
 github "mparticle/mparticle-apple-sdk" ~> 8.0

--- a/mParticle-CleverTap.podspec
+++ b/mParticle-CleverTap.podspec
@@ -16,10 +16,10 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-CleverTap/*.{h,m}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.ios.dependency 'CleverTap-iOS-SDK', '~> 3.8'
+    s.ios.dependency 'CleverTap-iOS-SDK', '~> 3.9'
 
     s.tvos.deployment_target = "9.0"
     s.tvos.source_files      = 'mParticle-CleverTap/*.{h,m}'
     s.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.tvos.dependency 'CleverTap-iOS-SDK', '~> 3.8'
+    s.tvos.dependency 'CleverTap-iOS-SDK', '~> 3.9'
 end


### PR DESCRIPTION
- Update CleverTap SDK version to 3.9

