### PR TITLE
feat: Update Clevertap SDK to Version 5.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
                .upToNextMajor(from: "8.0.0")),
       .package(name: "CleverTapSDK",
                url: "https://github.com/CleverTap/clevertap-ios-sdk",
-               .upToNextMajor(from: "4.2.0")),
+               .upToNextMajor(from: "5.2.0")),
     ],
     targets: [
         .target(

--- a/mParticle-CleverTap.podspec
+++ b/mParticle-CleverTap.podspec
@@ -16,10 +16,10 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-CleverTap/*.{h,m}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.ios.dependency 'CleverTap-iOS-SDK', '~> 4.2'
+    s.ios.dependency 'CleverTap-iOS-SDK', '~> 5.2'
 
     s.tvos.deployment_target = "9.0"
     s.tvos.source_files      = 'mParticle-CleverTap/*.{h,m}'
     s.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.tvos.dependency 'CleverTap-iOS-SDK', '~> 4.2'
+    s.tvos.dependency 'CleverTap-iOS-SDK', '~> 5.2'
 end


### PR DESCRIPTION
## Summary
 - Update to use Clevertap 5.x

 ## Testing Plan
 - Confirmed locally and tested end to end for a day (didn't see any problems) until I seemed to get locked out of our clevertap account.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5877
