### PR TITLE
chore: Update clevertap ios sdk to v5.x

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "clevertap/clevertap-ios-sdk" ~> 4.2
+github "clevertap/clevertap-ios-sdk" ~> 5.2
 github "mparticle/mparticle-apple-sdk" ~> 8.0

--- a/mParticle-CleverTap.podspec
+++ b/mParticle-CleverTap.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-CleverTap"
-    s.version          = "8.1.1"
+    s.version          = "8.2.0"
     s.summary          = "CleverTap integration for mParticle"
 
     s.description      = <<-DESC
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
 
     s.tvos.deployment_target = "9.0"
     s.tvos.source_files      = 'mParticle-CleverTap/*.{h,m}'
-    s.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
+    s.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.2'
     s.tvos.dependency 'CleverTap-iOS-SDK', '~> 5.2'
 end

--- a/mParticle-CleverTap.podspec
+++ b/mParticle-CleverTap.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-CleverTap"
-    s.version          = "8.2.0"
+    s.version          = "8.1.1"
     s.summary          = "CleverTap integration for mParticle"
 
     s.description      = <<-DESC
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
 
     s.tvos.deployment_target = "9.0"
     s.tvos.source_files      = 'mParticle-CleverTap/*.{h,m}'
-    s.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.2'
+    s.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
     s.tvos.dependency 'CleverTap-iOS-SDK', '~> 5.2'
 end

--- a/mParticle-CleverTap.podspec
+++ b/mParticle-CleverTap.podspec
@@ -16,10 +16,10 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-CleverTap/*.{h,m}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.ios.dependency 'CleverTap-iOS-SDK', '~> 4.2'
+    s.ios.dependency 'CleverTap-iOS-SDK', '~> 5.2'
 
     s.tvos.deployment_target = "9.0"
     s.tvos.source_files      = 'mParticle-CleverTap/*.{h,m}'
     s.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.tvos.dependency 'CleverTap-iOS-SDK', '~> 4.2'
+    s.tvos.dependency 'CleverTap-iOS-SDK', '~> 5.2'
 end

--- a/mParticle-CleverTap/MPKitCleverTap.m
+++ b/mParticle-CleverTap/MPKitCleverTap.m
@@ -13,6 +13,8 @@ NSString *const kUserIdField = @"userIdField";
 NSString *const ctCleverTapIdIntegrationKey = @"clevertap_id_integration_setting";
 NSString *const kCTTransactionID = @"Transaction Id";
 NSString *const kCTChargedID = @"Charged ID";
+NSString *const libName = @"mParticle-iOS";
+int const libVersion = 80101;
 
 @implementation MPKitCleverTap
 
@@ -53,6 +55,8 @@ NSString *const kCTChargedID = @"Charged ID";
         [[CleverTap sharedInstance] notifyApplicationLaunchedWithOptions:nil];
         
         self->_started = YES;
+        
+        [self setLibrary:libName libVersion:libVersion];
         
         NSString *cleverTapID = [[CleverTap sharedInstance] profileGetCleverTapID];
         if (cleverTapID) {
@@ -271,6 +275,12 @@ NSString *const kCTChargedID = @"Charged ID";
 - (MPKitExecStatus *)setOptOut:(BOOL)optOut {
     [[CleverTap sharedInstance] setOptOut:optOut];
     return [self execStatus:MPKitReturnCodeSuccess];
+}
+
+#pragma mark SetLibrary
+- (nonnull MPKitExecStatus *)setLibrary:(nonnull NSString *)libName libVersion:(int)libVersion{
+    [clevertap setLibrary:libName];
+    [clevertap setCustomSdkVersion:libName version:libVersion];
 }
 
 @end

--- a/mParticle-CleverTap/MPKitCleverTap.m
+++ b/mParticle-CleverTap/MPKitCleverTap.m
@@ -14,7 +14,7 @@ NSString *const ctCleverTapIdIntegrationKey = @"clevertap_id_integration_setting
 NSString *const kCTTransactionID = @"Transaction Id";
 NSString *const kCTChargedID = @"Charged ID";
 NSString *const libName = @"mParticle-iOS";
-int const libVersion = 80200;
+int const libVersion = 80101;
 
 @implementation MPKitCleverTap
 

--- a/mParticle-CleverTap/MPKitCleverTap.m
+++ b/mParticle-CleverTap/MPKitCleverTap.m
@@ -14,7 +14,7 @@ NSString *const ctCleverTapIdIntegrationKey = @"clevertap_id_integration_setting
 NSString *const kCTTransactionID = @"Transaction Id";
 NSString *const kCTChargedID = @"Charged ID";
 NSString *const libName = @"mParticle-iOS";
-int const libVersion = 80101;
+int const libVersion = 80200;
 
 @implementation MPKitCleverTap
 
@@ -56,7 +56,8 @@ int const libVersion = 80101;
         
         self->_started = YES;
         
-        [self setLibrary:libName libVersion:libVersion];
+        [clevertap setLibrary:libName];
+        [clevertap setCustomSdkVersion:libName version:libVersion];
         
         NSString *cleverTapID = [[CleverTap sharedInstance] profileGetCleverTapID];
         if (cleverTapID) {
@@ -275,12 +276,6 @@ int const libVersion = 80101;
 - (MPKitExecStatus *)setOptOut:(BOOL)optOut {
     [[CleverTap sharedInstance] setOptOut:optOut];
     return [self execStatus:MPKitReturnCodeSuccess];
-}
-
-#pragma mark SetLibrary
-- (nonnull MPKitExecStatus *)setLibrary:(nonnull NSString *)libName libVersion:(int)libVersion{
-    [clevertap setLibrary:libName];
-    [clevertap setCustomSdkVersion:libName version:libVersion];
 }
 
 @end


### PR DESCRIPTION
 ## Summary
 - Update clevertap-ios-sdk to v5.2.2 
-  Update clevertap kit to track library name and version

 ## Testing Plan
 - This was tested locally and working fine.
