### PR TITLE
chore: Update clevertap ios sdk to v6.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,10 +13,10 @@ let package = Package(
     dependencies: [
       .package(name: "mParticle-Apple-SDK",
                url: "https://github.com/mParticle/mparticle-apple-sdk",
-               .upToNextMajor(from: "8.0.0")),
+               .upToNextMajor(from: "8.3.0")),
       .package(name: "CleverTapSDK",
                url: "https://github.com/CleverTap/clevertap-ios-sdk",
-               .upToNextMajor(from: "5.2.0")),
+               .upToNextMajor(from: "6.1.0")),
     ],
     targets: [
         .target(

--- a/Podfile
+++ b/Podfile
@@ -2,12 +2,12 @@ use_frameworks!
 
 target 'mParticle-CleverTap' do
   pod 'mParticle-Apple-SDK', '~> 8'
-  pod 'CleverTap-iOS-SDK', '~> 5.2'
+  pod 'CleverTap-iOS-SDK', '~> 6.1'
 end
 
 target 'mParticle_CleverTapTests' do
     pod 'mParticle-Apple-SDK', '~> 8'
-    pod 'CleverTap-iOS-SDK', '~> 5.2'
+    pod 'CleverTap-iOS-SDK', '~> 6.1'
     pod 'Quick'
     pod 'Nimble'
     pod 'OCMock'

--- a/mParticle-CleverTap.podspec
+++ b/mParticle-CleverTap.podspec
@@ -16,10 +16,10 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-CleverTap/*.{h,m}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.ios.dependency 'CleverTap-iOS-SDK', '~> 5.2'
+    s.ios.dependency 'CleverTap-iOS-SDK', '~> 6.1'
 
     s.tvos.deployment_target = "9.0"
     s.tvos.source_files      = 'mParticle-CleverTap/*.{h,m}'
     s.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.tvos.dependency 'CleverTap-iOS-SDK', '~> 5.2'
+    s.tvos.dependency 'CleverTap-iOS-SDK', '~> 6.1'
 end


### PR DESCRIPTION
**Summary**

- Update clevertap-ios-sdk to v6.1.0

**Testing Plan**

- This was tested locally and working fine.
