### PR TITLE
feat: Improve Privacy Manifest support for iOS 17

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,16 +13,17 @@ let package = Package(
     dependencies: [
       .package(name: "mParticle-Apple-SDK",
                url: "https://github.com/mParticle/mparticle-apple-sdk",
-               .upToNextMajor(from: "8.0.0")),
+               .upToNextMajor(from: "8.22.0")),
       .package(name: "CleverTapSDK",
                url: "https://github.com/CleverTap/clevertap-ios-sdk",
-               .upToNextMajor(from: "6.2.0")),
+               .upToNextMajor(from: "6.2.1")),
     ],
     targets: [
         .target(
             name: "mParticle-CleverTap",
             dependencies: ["mParticle-Apple-SDK", "CleverTapSDK"],
             path: "mParticle-CleverTap",
+            resources: [.process("PrivacyInfo.xcprivacy")],
             publicHeadersPath: "."
         ),
     ]

--- a/mParticle-CleverTap.podspec
+++ b/mParticle-CleverTap.podspec
@@ -15,11 +15,13 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-CleverTap/*.{h,m}'
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
+    s.ios.resource_bundles  = { 'mParticle-CleverTap-Privacy' => ['mParticle-CleverTap/PrivacyInfo.xcprivacy'] }
+    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.22'
     s.ios.dependency 'CleverTap-iOS-SDK', '~> 6.2'
 
     s.tvos.deployment_target = "9.0"
     s.tvos.source_files      = 'mParticle-CleverTap/*.{h,m}'
-    s.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
+    s.ios.resource_bundles  = { 'mParticle-CleverTap-Privacy' => ['mParticle-CleverTap/PrivacyInfo.xcprivacy'] }
+    s.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.22'
     s.tvos.dependency 'CleverTap-iOS-SDK', '~> 6.2'
 end

--- a/mParticle-CleverTap/PrivacyInfo.xcprivacy
+++ b/mParticle-CleverTap/PrivacyInfo.xcprivacy
@@ -7,12 +7,8 @@
     <key>NSPrivacyTrackingDomains</key>
     <array/>
     <key>NSPrivacyCollectedDataTypes</key>
-    <array>
-        <dict/>
-    </array>
+    <array/>
     <key>NSPrivacyAccessedAPITypes</key>
-    <array>
-        <dict/>
-    </array>
+    <array/>
 </dict>
 </plist>


### PR DESCRIPTION
 ## Summary
 - Fix parsing issue due to empty dict
 - Ensure manifest is included by package managers

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Confirmed in test apps

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6413